### PR TITLE
Improve VS Code completion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 			"source.sortImports": "explicit"
 		}
 	},
-	"haxe.enableExtendedIndentation": true
+	"haxe.enableExtendedIndentation": true,
+	"lime.projectFile": "example/Project.xml"
 }


### PR DESCRIPTION
We can get nicer completion in VS Code if we make the Lime extension use the example's Project.xml instead of relying on a hxml